### PR TITLE
Sms 1361 improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,20 @@ The Esendex Java SDK is an easy to use client for the Esendex REST API which you
 It contains a set of services for sending SMS and Voice messages, receiving SMS, tracking the status of your sent messages and more.
 
 Full details at http://developers.esendex.com/SDKs/Java-SDK
+
+
+## Logging
+
+The SDK contains logging calls using the Apache Commons Logging framework. By default, this will write all log messages of INFO level or above to `System.err`.
+
+To configure this logging, clients should follow the [configuration process for Apache Commons Logging](http://commons.apache.org/proper/commons-logging/apidocs/org/apache/commons/logging/package-summary.html). This will allow the SDK's logging to be integrated with that of the hosting application.
+
+Logger instances are obtained on a per-class basis within the SDK based on the class name, so if your chosen framework supports configuring logging by context name you can target the SDK's messages by getting anything under the `esendex` toplevel namespace.
+
+If you're not using a logging framework which Apache Commons Logging recognises then it will probably be defaulting to the `Jdk14Logger`, which uses `java.util.logging` to issue its log messages. This can be configured using its own configuration methods. For example, you can set the Esendex SDK to `WARNING` level or above:
+
+> Logger.getLogger("esendex").setLevel(Level.WARNING);
+
+Otherwise, you'll need to work out the appropriate configuration methods for your logging framework. To determine which one ACL is selecting, set the system property "org.apache.commons.logging.diagnostics.dest" to "STDOUT" or "STDERR" as preferred, and it will output all the steps in the discovery process for which log provider it selected.
+
+For more information, consult the Apache Commons Logging user guide.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ If you're not using a logging framework which Apache Commons Logging recognises 
 Otherwise, you'll need to work out the appropriate configuration methods for your logging framework. To determine which one ACL is selecting, set the system property "org.apache.commons.logging.diagnostics.dest" to "STDOUT" or "STDERR" as preferred, and it will output all the steps in the discovery process for which log provider it selected.
 
 For more information, consult the Apache Commons Logging user guide.
+
+## Development
+
+To run all the tests you need an active Esendex account with permissions on the full set of supported Esendex products.
+
+Copy `esendex_test.properties.example` as `esendex_test.properties` and fill in your account information and a mobile number used as a message target.
+
+Esendex developers can use the `tests.domain` key to run the tests against alternate environments.

--- a/README.md
+++ b/README.md
@@ -12,19 +12,22 @@ Full details at http://developers.esendex.com/SDKs/Java-SDK
 
 ## Logging
 
-The SDK contains logging calls using the Apache Commons Logging framework. By default, this will write all log messages of INFO level or above to `System.err`.
+The SDK contains logging calls using the Apache Commons Logging framework. This logging is expected to be helpful only for diagnostic purposes, and logs only at DEBUG level.
+
+**Please note** that the DEBUG level log messages include the entirety of messages sent to and from the Esendex servers, and will thus contain message contents, recipients and originators. This almost certainly contains personally identifiable information (PID), and so the DEBUG level logging should be used only with appropriate consideration.
 
 To configure this logging, clients should follow the [configuration process for Apache Commons Logging](http://commons.apache.org/proper/commons-logging/apidocs/org/apache/commons/logging/package-summary.html). This will allow the SDK's logging to be integrated with that of the hosting application.
 
 Logger instances are obtained on a per-class basis within the SDK based on the class name, so if your chosen framework supports configuring logging by context name you can target the SDK's messages by getting anything under the `esendex` toplevel namespace.
 
-If you're not using a logging framework which Apache Commons Logging recognises then it will probably be defaulting to the `Jdk14Logger`, which uses `java.util.logging` to issue its log messages. This can be configured using its own configuration methods. For example, you can set the Esendex SDK to `WARNING` level or above:
+If you're not using a logging framework which Apache Commons Logging recognises then it will probably be defaulting to the `Jdk14Logger`, which uses `java.util.logging` to issue its log messages. This can be configured using its own configuration methods. For example, you can turn on the DEBUG logging for the Esendex SDK:
 
-> Logger.getLogger("esendex").setLevel(Level.WARNING);
+> Logger.getLogger("esendex").setLevel(Level.DEBUG);
 
 Otherwise, you'll need to work out the appropriate configuration methods for your logging framework. To determine which one ACL is selecting, set the system property "org.apache.commons.logging.diagnostics.dest" to "STDOUT" or "STDERR" as preferred, and it will output all the steps in the discovery process for which log provider it selected.
 
 For more information, consult the Apache Commons Logging user guide.
+
 
 ## Development
 

--- a/esendex-java-sdk.iml
+++ b/esendex-java-sdk.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/src/main/java/esendex/sdk/java/service/resource/base/Resource.java
+++ b/src/main/java/esendex/sdk/java/service/resource/base/Resource.java
@@ -184,9 +184,9 @@ public abstract class Resource {
 		HttpRequestMethod method = getRequestMethod();
 		String data = getRequestData();
 
-		log.info(getClass().getSimpleName());
-		log.info(method + " to: " + url);
-		log.info("Request: " + XmlPrettyPrinter.format(data));
+		log.debug(getClass().getSimpleName());
+		log.debug(method + " to: " + url);
+		log.debug("Request: " + XmlPrettyPrinter.format(data));
 
 		httpResponse = HttpConnectorFactory.getConnector().connect(
 				url,
@@ -194,7 +194,7 @@ public abstract class Resource {
 				data,
 				authenticator);
 
-		log.info("Response: " + httpResponse);
+		log.debug("Response: " + httpResponse);
 
 		if (! isHttpOkay()) throw new HttpException(
 				"Status code: " + httpResponse.getStatusCode());

--- a/src/main/java/esendex/sdk/java/service/resource/base/XmlRequester.java
+++ b/src/main/java/esendex/sdk/java/service/resource/base/XmlRequester.java
@@ -26,7 +26,7 @@ public class XmlRequester<Q extends Dto> {
 		if (requestDto == null)
 			throw new NullPointerException("Argument must not be null");
 
-		log.info("Request class: " + requestDto.getClass().getSimpleName());
+		log.debug("Request class: " + requestDto.getClass().getSimpleName());
 		this.parser = XmlParserFactory.getInstance();
 		this.requestDto = requestDto;
 	}
@@ -36,7 +36,7 @@ public class XmlRequester<Q extends Dto> {
 	 * @return the request data to submit
 	 */
 	public String getRequestData() {
-		log.info("request dto: " + requestDto);
+		log.debug("request dto: " + requestDto);
 		return parser.toXml(requestDto);
 	}
 }

--- a/src/main/java/esendex/sdk/java/service/resource/base/XmlResponder.java
+++ b/src/main/java/esendex/sdk/java/service/resource/base/XmlResponder.java
@@ -37,9 +37,9 @@ public class XmlResponder<S> {
 
     @SuppressWarnings("unchecked")
 	private void createResponseObject() throws EsendexException {
-		log.info("Response: " + XmlPrettyPrinter.format(responseContent));
+		log.debug("Response: " + XmlPrettyPrinter.format(responseContent));
 		responseDto = (S) parser.fromXml(responseContent);
-		log.info("Response class: " + responseDto.getClass().getSimpleName());
+		log.debug("Response class: " + responseDto.getClass().getSimpleName());
 	}
 
 	/**


### PR DESCRIPTION
Converts all the logging from INFO to DEBUG level which seems more appropriate (and will disable it by default in most logging configurations).

Also updates the README file to explain some of this, and some hints for developers trying to run the tests.